### PR TITLE
Color on player error message when player doesn't have permission

### DIFF
--- a/src/main/java/net/laboulangerie/laboulangeriecore/commands/SpawnCmd.java
+++ b/src/main/java/net/laboulangerie/laboulangeriecore/commands/SpawnCmd.java
@@ -24,7 +24,7 @@ public class SpawnCmd implements CommandExecutor {
         if (!args[0].equalsIgnoreCase("set")) return false;
 
         if (!player.hasPermission("laboulangeriecore.admin")) {
-            player.sendMessage("!4You don't have permission to use this command!");
+            player.sendMessage("§4You don't have permission to use this command!");
             return true;
         }
 


### PR DESCRIPTION
Have error when the player use `/spawn set` and doesn't have permission `laboulangeriecore.admin` the error message color not set. <br/>

```JAVA
FROM: player.sendMessage("!4You don't have permission to use this command!");
TO: player.sendMessage("§4You don't have permission to use this command!");
```