### PR TITLE
Rework de l'authentification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,12 @@
             <artifactId>worldguard-bukkit</artifactId>
             <version>7.0.8</version>
             <scope>provided</scope>
+        </dependency> 
+        <dependency>
+            <groupId>com.github.angeschossen</groupId>
+            <artifactId>LandsAPI</artifactId>
+            <version>version</version> <!-- Version à modifier avant déploiement -->
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/net/laboulangerie/laboulangeriecore/authenticate/Authenticable.java
+++ b/src/main/java/net/laboulangerie/laboulangeriecore/authenticate/Authenticable.java
@@ -64,7 +64,20 @@ public class Authenticable {
     }
 
     public static String parseLore(String authority, AuthorityType type) {
-        return LaBoulangerieCore.PLUGIN.getConfig().getString("authenticate.lore").replaceAll("%authority%", authority)
-                .replaceAll("%type%", type.getSuffix());
+        switch(type.getSuffix) // DATE A REVOIR !!!
+        case "joueur":
+            return LaBoulangerieCore.PLUGIN.getConfig().getString("authenticate.lore-player").replaceAll("%authority%", authority)
+                    .replaceAll("%date%", type.getSuffix());
+        case "ville":
+            return LaBoulangerieCore.PLUGIN.getConfig().getString("authenticate.lore-land").replaceAll("%authority%", authority)
+                    .replaceAll("%date%", type.getSuffix());
+        case "nation":
+            return LaBoulangerieCore.PLUGIN.getConfig().getString("authenticate.lore-nation").replaceAll("%authority%", authority)
+                    .replaceAll("%date%", type.getSuffix());
+        case "entreprise":
+            return LaBoulangerieCore.PLUGIN.getConfig().getString("authenticate.lore-company").replaceAll("%authority%", authority)
+                    .replaceAll("%date%", type.getSuffix());
+        default:
+            break;
     }
 }

--- a/src/main/java/net/laboulangerie/laboulangeriecore/authenticate/Authenticable.java
+++ b/src/main/java/net/laboulangerie/laboulangeriecore/authenticate/Authenticable.java
@@ -13,7 +13,8 @@ import net.laboulangerie.laboulangeriecore.LaBoulangerieCore;
 
 public class Authenticable {
     private ItemStack item;
-
+    private LandsIntegration api = LandsIntegration.of(this);
+    
     public Authenticable(ItemStack item) {
         this.item = item;
     }

--- a/src/main/java/net/laboulangerie/laboulangeriecore/authenticate/Authenticable.java
+++ b/src/main/java/net/laboulangerie/laboulangeriecore/authenticate/Authenticable.java
@@ -64,19 +64,19 @@ public class Authenticable {
     }
 
     public static String parseLore(String authority, AuthorityType type) {
-        switch(type.getSuffix) // DATE A REVOIR !!!
+        switch(type.getSuffix){ // DATE A REVOIR !!!
         case "joueur":
             return LaBoulangerieCore.PLUGIN.getConfig().getString("authenticate.lore-player").replaceAll("%authority%", authority)
-                    .replaceAll("%date%", type.getSuffix());
+                    .replaceAll("%date%", LaBoulangerieCore.PLUGIN);
         case "ville":
             return LaBoulangerieCore.PLUGIN.getConfig().getString("authenticate.lore-land").replaceAll("%authority%", authority)
-                    .replaceAll("%date%", type.getSuffix());
+                    .replaceAll("%date%", );
         case "nation":
             return LaBoulangerieCore.PLUGIN.getConfig().getString("authenticate.lore-nation").replaceAll("%authority%", authority)
-                    .replaceAll("%date%", type.getSuffix());
+                    .replaceAll("%date%", );
         case "entreprise":
             return LaBoulangerieCore.PLUGIN.getConfig().getString("authenticate.lore-company").replaceAll("%authority%", authority)
-                    .replaceAll("%date%", type.getSuffix());
+                    .replaceAll("%date%", );
         default:
             break;
     }

--- a/src/main/java/net/laboulangerie/laboulangeriecore/authenticate/AuthorityType.java
+++ b/src/main/java/net/laboulangerie/laboulangeriecore/authenticate/AuthorityType.java
@@ -4,6 +4,7 @@ public enum AuthorityType {
     PLAYER("p", "joueur"),
     TOWN("t", "ville"),
     NATION("n", "nation"),
+    COMPANY("c", "entreprise")
     INVALID(null, null);
 
     private String prefix;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,8 @@
 authenticate:
-    lore: "§6Authentifié par %authority% (%type%)"
+    lore-player: "§6Authentifié par %authority%\nLe %date%."
+    lore-land: "§6Authentifié par la ville de %authority%\nLe %date%."
+    lore-nation: "§6Authentifié par la nation de %authority%\nLe %date%."
+    lore-company: "§6Authentifié par l'entreprise %authority%\nLe %date%."
 
 tab:
     # MiniMessage format and PAPI placeholders allowed


### PR DESCRIPTION
### /!\ NE PAS MERGE /!\
Cette branche est uniquement un test et une proposition, rien n'as encore été validé et le code est incomplet.

Ajouts :
- Système d'entreprise
- Support de Lands, mais pas de Towny
- Support du calendrier gaiartois
- Différents lores possible en fonction de l'entité qui authentifie (joueur, ville, nation ou entreprise)
- Un hover sur les authentification ville, nation et entreprise pour voir qui l'as authentifié

Je compte également ajouter une commande de désauthentification staff (donc forcée), une désauthentification joueur en essayant également d'introduire un système de reconnaissance de l'authentificateur (basé sur l'UUID du joueur, de la ville ou de la nation).

Je réfléchis aussi a une réaction spécifique de l'authentification aux livres écrits, @PainOchoco avait eu l'idée de faire un plugin qui overwrite totalement le pseudo des joueurs avec leurs surnom (RP), apparemment trop compliqué, ce qui pourrait être en revanche fait c'est de proposer la modification de l'auteur d'un livre via l'authentification. Un autre comportement pourrait être spécifique à la signature des traité en proposant un lore différent.

Le système d'entreprise est très expérimental et ne va pas forcément rester.